### PR TITLE
Return empty string when richPages is out of bounds

### DIFF
--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -315,6 +315,7 @@ public abstract class BookEditScreenMixin extends Screen {
     // This method is only actively used when double-clicking to select a word.
     @Redirect(method = "getCurrentPageContent", at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;"))
     public Object getCurrentPageContent(List<String> pages, int page) {
+        if (this.currentPage >= this.richPages.size()) return "";
         return this.richPages.get(page).getPlainText();
     }
 


### PR DESCRIPTION
This is done to fix https://github.com/replaceitem/symbol-chat/issues/44.
When both scribble and my mod are present, this crash occurs.

My mod calls `BookEditScreen.getCurrentPageContent()` when closing the screen, which happens after `removeEmptyPages()` removed all empty pages.

When the overwritten `removeEmptyPages` deletes all empty `richPages`, the vanilla `pages` remain unchanged, meaning the out of bounds check in `BookEditScreen.getCurrentPageContent` checks for out of bounds in `pages`, but `richPages.get()` could throw out of bounds, causing the crash.

This PR introduces a upper bounds check with `richPages` and returns `""` like the vanilla implementation does, to make sure this can't happen.