### PR TITLE
Run tests on build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,8 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - run: ./gradlew chiseledBuild
+      - name: Run Tests
+        run: ./gradlew chiseledTest
+
+      - name: Run Build
+        run: ./gradlew chiseledBuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - run: ./gradlew chiseledBuild
+      - name: Run Tests
+        run: ./gradlew chiseledTest
+
+      - name: Run Build
+        run: ./gradlew chiseledBuild
 
       - name: Fetch changelog
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,11 @@ tasks {
 
     "test"(Test::class) {
         useJUnitPlatform()
+
+        // To log test status in console
+        testLogging {
+            events("passed", "skipped", "failed")
+        }
     }
 }
 

--- a/src/test/java/me/chrr/scribble/RichTextReplaceTest.java
+++ b/src/test/java/me/chrr/scribble/RichTextReplaceTest.java
@@ -203,9 +203,4 @@ public class RichTextReplaceTest {
         assertEquals(otherColor, richText.getSegments().get(3).color());
         assertEquals(otherModifiers, richText.getSegments().get(3).modifiers());
     }
-
-    @Test
-    public void testThatAlwaysFails() {
-        assertTrue(false);
-    }
 }

--- a/src/test/java/me/chrr/scribble/RichTextReplaceTest.java
+++ b/src/test/java/me/chrr/scribble/RichTextReplaceTest.java
@@ -203,4 +203,9 @@ public class RichTextReplaceTest {
         assertEquals(otherColor, richText.getSegments().get(3).color());
         assertEquals(otherModifiers, richText.getSegments().get(3).modifiers());
     }
+
+    @Test
+    public void testThatAlwaysFails() {
+        assertTrue(false);
+    }
 }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -11,6 +11,12 @@ val chiseledVersions = providers.environmentVariable("CHISELED_VERSIONS")
 val chiseledProjects = stonecutter.versions
     .filter { chiseledVersions?.contains(it.version) ?: true }
 
+stonecutter registerChiseled tasks.register("chiseledTest", stonecutter.chiseled) {
+    versions.set(chiseledProjects)
+    group = "project"
+    ofTask("test")
+}
+
 stonecutter registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {
     versions.set(chiseledProjects)
     group = "project"


### PR DESCRIPTION
This PR adds a `chiseledTest` gradle task and runs it before building for the `build` and `release` workflows.

In case the `chiseledTest` task fails - the workflow fails as well, to notify the developer and prevent a broken build from being released. Successed/failed workflows examples [here](https://github.com/wiskiw/ScribbleMC/actions).