### PR TITLE
feat: add a config option to center the book GUI vertically

### DIFF
--- a/src/main/java/me/chrr/scribble/Scribble.java
+++ b/src/main/java/me/chrr/scribble/Scribble.java
@@ -2,7 +2,6 @@ package me.chrr.scribble;
 
 import me.chrr.scribble.config.ConfigManager;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,19 +14,12 @@ public class Scribble implements ClientModInitializer {
 
     public static final ConfigManager CONFIG_MANAGER = new ConfigManager();
 
-    public static boolean shouldCenter = false;
-
     @Override
     public void onInitializeClient() {
         try {
             CONFIG_MANAGER.load();
         } catch (IOException e) {
             LOGGER.error("failed to load config", e);
-        }
-
-        if (FabricLoader.getInstance().isModLoaded("fixbookgui")) {
-            LOGGER.info("FixBookGUI is centering the book screen, adapting...");
-            Scribble.shouldCenter = true;
         }
     }
 

--- a/src/main/java/me/chrr/scribble/Scribble.java
+++ b/src/main/java/me/chrr/scribble/Scribble.java
@@ -23,6 +23,10 @@ public class Scribble implements ClientModInitializer {
         }
     }
 
+    public static int getBookScreenYOffset(int screenHeight) {
+        return Scribble.CONFIG_MANAGER.getConfig().centerBookGui ? (screenHeight - 192) / 3 : 0;
+    }
+
     public static Identifier id(String path) {
         //? if >=1.21 {
         return Identifier.of(MOD_ID, path);

--- a/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
+++ b/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
@@ -45,7 +45,7 @@ public class ClothConfigScreenFactory {
                         Text.translatable("config.scribble.option.center_book_gui"),
                         config.centerBookGui
                 )
-                .setDefaultValue(false)
+                .setDefaultValue(true)
                 .setSaveConsumer((value) -> config.centerBookGui = value)
                 .build());
 

--- a/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
+++ b/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
@@ -41,6 +41,14 @@ public class ClothConfigScreenFactory {
                 .setSaveConsumer((value) -> config.copyFormattingCodes = value)
                 .build());
 
+        category.addEntry(entryBuilder.startBooleanToggle(
+                        Text.translatable("config.scribble.option.center_book_gui"),
+                        config.centerBookGui
+                )
+                .setDefaultValue(false)
+                .setSaveConsumer((value) -> config.centerBookGui = value)
+                .build());
+
         return builder.build();
     }
 }

--- a/src/main/java/me/chrr/scribble/config/Config.java
+++ b/src/main/java/me/chrr/scribble/config/Config.java
@@ -11,6 +11,9 @@ public class Config {
     @SerializedName("copy_formatting_codes")
     public boolean copyFormattingCodes = true;
 
+    @SerializedName("center_book_gui")
+    public boolean centerBookGui = false;
+
     public void upgrade() {
         this.version = VERSION;
     }

--- a/src/main/java/me/chrr/scribble/config/Config.java
+++ b/src/main/java/me/chrr/scribble/config/Config.java
@@ -12,7 +12,7 @@ public class Config {
     public boolean copyFormattingCodes = true;
 
     @SerializedName("center_book_gui")
-    public boolean centerBookGui = false;
+    public boolean centerBookGui = true;
 
     public void upgrade() {
         this.version = VERSION;

--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -161,13 +161,10 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     @Unique
     private IconButtonWidget loadBookButton;
 
-    // Dummy constructor to match super class. The mixin derives from
-    // `Screen` so we don't have to shadow as many methods.
-    // This should never be called.
-    protected BookEditScreenMixin(Text title) {
-        super(title);
+    // Dummy constructor to match super class.
+    private BookEditScreenMixin() {
+        super(null);
     }
-
 
     @Unique
     private String getRawClipboard() {
@@ -223,14 +220,9 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     }
 
     @Unique
-    private int getYOffset() {
-        return Scribble.CONFIG_MANAGER.getConfig().centerBookGui ? (height - 192) / 3 : 0;
-    }
-
-    @Unique
     private void initButtons() {
         int x = this.width / 2 + 78;
-        int y = getYOffset() + 12;
+        int y = Scribble.getBookScreenYOffset(height) + 12;
 
         // Modifier buttons
         boldButton = addModifierButton(
@@ -511,15 +503,15 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     @ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIII)V"), index = 3)
     //?} else
     /*@ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V"), index = 2)*/
-    public int overrideBackgroundY(int y) {
-        return getYOffset() + y;
+    public int shiftBackgroundY(int y) {
+        return Scribble.getBookScreenYOffset(height) + y;
     }
 
     // If we need to center the GUI, we shift the Y of the button dimensions down.
     @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
-    public <T extends Element & Drawable & Selectable> T overrideButtonY(BookEditScreen screen, T element) {
+    public <T extends Element & Drawable & Selectable> T shiftButtonY(BookEditScreen screen, T element) {
         if (element instanceof Widget widget) {
-            widget.setY(widget.getY() + getYOffset());
+            widget.setY(widget.getY() + Scribble.getBookScreenYOffset(height));
         }
 
         return addDrawableChild(element);
@@ -528,13 +520,13 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     // If we need to center the GUI, we shift any mouse clicks down.
     @ModifyArg(method = "mouseClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;screenPositionToAbsolutePosition(Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;)Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;"))
     public BookEditScreen.Position shiftMouseClicks(BookEditScreen.Position position) {
-        return new BookEditScreen.Position(position.x, position.y - getYOffset());
+        return new BookEditScreen.Position(position.x, position.y - Scribble.getBookScreenYOffset(height));
     }
 
     // If we need to center the GUI, we shift any mouse drags down.
     @ModifyArg(method = "mouseDragged", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;screenPositionToAbsolutePosition(Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;)Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;"))
     public BookEditScreen.Position shiftMouseDrags(BookEditScreen.Position position) {
-        return new BookEditScreen.Position(position.x, position.y - getYOffset());
+        return new BookEditScreen.Position(position.x, position.y - Scribble.getBookScreenYOffset(height));
     }
 
     // When rendering, we translate the matrices of the draw context to draw the text further down if needed.
@@ -542,7 +534,7 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
     public void translateRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         context.getMatrices().push();
-        context.getMatrices().translate(0f, getYOffset(), 0f);
+        context.getMatrices().translate(0f, Scribble.getBookScreenYOffset(height), 0f);
     }
 
     // At the end of rendering, we need to pop those matrices we pushed.

--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -15,9 +15,14 @@ import me.chrr.scribble.tool.Restorable;
 import me.chrr.scribble.tool.commandmanager.Command;
 import me.chrr.scribble.tool.commandmanager.CommandManager;
 import net.minecraft.client.font.TextHandler;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.screen.ConfirmScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.BookEditScreen;
+import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.client.util.SelectionManager;
 import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.entity.player.PlayerEntity;
@@ -218,13 +223,14 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     }
 
     @Unique
+    private int getYOffset() {
+        return Scribble.CONFIG_MANAGER.getConfig().centerBookGui ? (height - 192) / 3 : 0;
+    }
+
+    @Unique
     private void initButtons() {
         int x = this.width / 2 + 78;
-        int y = 12;
-
-        if (Scribble.shouldCenter) {
-            y += (height - 192) / 3;
-        }
+        int y = getYOffset() + 12;
 
         // Modifier buttons
         boldButton = addModifierButton(
@@ -498,6 +504,51 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
             Command command = new InsertPageCommand(richPages, currentPage, this);
             commandManager.execute(command);
         }
+    }
+
+    // If we need to center the GUI, we shift the Y of the texture draw call down.
+    //? if >=1.21.2 {
+    @ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIII)V"), index = 3)
+    //?} else
+    /*@ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V"), index = 2)*/
+    public int overrideBackgroundY(int y) {
+        return getYOffset() + y;
+    }
+
+    // If we need to center the GUI, we shift the Y of the button dimensions down.
+    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
+    public <T extends Element & Drawable & Selectable> T overrideButtonY(BookEditScreen screen, T element) {
+        if (element instanceof Widget widget) {
+            widget.setY(widget.getY() + getYOffset());
+        }
+
+        return addDrawableChild(element);
+    }
+
+    // If we need to center the GUI, we shift any mouse clicks down.
+    @ModifyArg(method = "mouseClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;screenPositionToAbsolutePosition(Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;)Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;"))
+    public BookEditScreen.Position shiftMouseClicks(BookEditScreen.Position position) {
+        return new BookEditScreen.Position(position.x, position.y - getYOffset());
+    }
+
+    // If we need to center the GUI, we shift any mouse drags down.
+    @ModifyArg(method = "mouseDragged", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;screenPositionToAbsolutePosition(Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;)Lnet/minecraft/client/gui/screen/ingame/BookEditScreen$Position;"))
+    public BookEditScreen.Position shiftMouseDrags(BookEditScreen.Position position) {
+        return new BookEditScreen.Position(position.x, position.y - getYOffset());
+    }
+
+    // When rendering, we translate the matrices of the draw context to draw the text further down if needed.
+    // Note that this happens after the parent screen render, so only the text in the book is shifted.
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+    public void translateRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        context.getMatrices().push();
+        context.getMatrices().translate(0f, getYOffset(), 0f);
+    }
+
+    // At the end of rendering, we need to pop those matrices we pushed.
+    @Inject(method = "render", at = @At(value = "RETURN"))
+    public void popRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        context.getMatrices().pop();
     }
 
     /**

--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -499,6 +499,8 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     }
 
     // If we need to center the GUI, we shift the Y of the texture draw call down.
+    // For 1.20.1, this draw call happens in render, so we don't need to do it separately.
+    //? if >=1.20.2 {
     //? if >=1.21.2 {
     @ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIII)V"), index = 3)
     //?} else
@@ -506,6 +508,7 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     public int shiftBackgroundY(int y) {
         return Scribble.getBookScreenYOffset(height) + y;
     }
+    //?}
 
     // If we need to center the GUI, we shift the Y of the button dimensions down.
     @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
@@ -531,14 +534,20 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
 
     // When rendering, we translate the matrices of the draw context to draw the text further down if needed.
     // Note that this happens after the parent screen render, so only the text in the book is shifted.
+    //? if >=1.20.2 {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+    //?} else
+    /*@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookEditScreen;renderBackground(Lnet/minecraft/client/gui/DrawContext;)V", shift = At.Shift.AFTER))*/
     public void translateRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         context.getMatrices().push();
         context.getMatrices().translate(0f, Scribble.getBookScreenYOffset(height), 0f);
     }
 
     // At the end of rendering, we need to pop those matrices we pushed.
+    //? if >=1.20.2 {
     @Inject(method = "render", at = @At(value = "RETURN"))
+    //?} else
+    /*@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V"))*/
     public void popRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         context.getMatrices().pop();
     }

--- a/src/main/java/me/chrr/scribble/mixin/BookScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookScreenMixin.java
@@ -20,6 +20,8 @@ public abstract class BookScreenMixin extends Screen {
     }
 
     // If we need to center the GUI, we shift the Y of the texture draw call down.
+    // For 1.20.1, this draw call happens in render, so we don't need to do it separately.
+    //? if >=1.20.2 {
     //? if >=1.21.2 {
     @ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIII)V"), index = 3)
     //?} else
@@ -27,6 +29,7 @@ public abstract class BookScreenMixin extends Screen {
     public int shiftBackgroundY(int y) {
         return Scribble.getBookScreenYOffset(height) + y;
     }
+    //?}
 
     // If we need to center the GUI, we shift the Y of the close buttons down.
     @Redirect(method = "addCloseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
@@ -56,7 +59,10 @@ public abstract class BookScreenMixin extends Screen {
 
     // When rendering, we translate the matrices of the draw context to draw the text further down if needed.
     // Note that this happens after the parent screen render, so only the text in the book is shifted.
+    //? if >=1.20.2 {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+    //?} else
+    /*@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookScreen;renderBackground(Lnet/minecraft/client/gui/DrawContext;)V", shift = At.Shift.AFTER))*/
     public void translateRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         context.getMatrices().push();
         context.getMatrices().translate(0f, Scribble.getBookScreenYOffset(height), 0f);
@@ -68,7 +74,10 @@ public abstract class BookScreenMixin extends Screen {
     }
 
     // At the end of rendering, we need to pop those matrices we pushed.
+    //? if >=1.20.2 {
     @Inject(method = "render", at = @At(value = "RETURN"))
+    //?} else
+    /*@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V"))*/
     public void popRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         context.getMatrices().pop();
     }

--- a/src/main/java/me/chrr/scribble/mixin/BookScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookScreenMixin.java
@@ -1,0 +1,75 @@
+package me.chrr.scribble.mixin;
+
+import me.chrr.scribble.Scribble;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.BookScreen;
+import net.minecraft.client.gui.widget.Widget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BookScreen.class)
+public abstract class BookScreenMixin extends Screen {
+    // Dummy constructor to match super class.
+    private BookScreenMixin() {
+        super(null);
+    }
+
+    // If we need to center the GUI, we shift the Y of the texture draw call down.
+    //? if >=1.21.2 {
+    @ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIII)V"), index = 3)
+    //?} else
+    /*@ModifyArg(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V"), index = 2)*/
+    public int shiftBackgroundY(int y) {
+        return Scribble.getBookScreenYOffset(height) + y;
+    }
+
+    // If we need to center the GUI, we shift the Y of the close buttons down.
+    @Redirect(method = "addCloseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
+    public <T extends Element & Drawable & Selectable> T shiftCloseButtonY(BookScreen instance, T element) {
+        if (element instanceof Widget widget) {
+            widget.setY(widget.getY() + Scribble.getBookScreenYOffset(height));
+        }
+
+        return addDrawableChild(element);
+    }
+
+    // If we need to center the GUI, we shift the Y of the page buttons down.
+    @Redirect(method = "addPageButtons", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BookScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
+    public <T extends Element & Drawable & Selectable> T shiftPageButtonY(BookScreen instance, T element) {
+        if (element instanceof Widget widget) {
+            widget.setY(widget.getY() + Scribble.getBookScreenYOffset(height));
+        }
+
+        return addDrawableChild(element);
+    }
+
+    // If we need to center the GUI, modify the coordinates to check.
+    @ModifyVariable(method = "getTextStyleAt", at = @At(value = "HEAD"), ordinal = 1, argsOnly = true)
+    public double shiftTextStyleY(double y) {
+        return y - Scribble.getBookScreenYOffset(height);
+    }
+
+    // When rendering, we translate the matrices of the draw context to draw the text further down if needed.
+    // Note that this happens after the parent screen render, so only the text in the book is shifted.
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+    public void translateRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        context.getMatrices().push();
+        context.getMatrices().translate(0f, Scribble.getBookScreenYOffset(height), 0f);
+    }
+
+    @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawHoverEvent(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Style;II)V"), index = 3)
+    public int shiftHoverTooltipY(int y) {
+        return y - Scribble.getBookScreenYOffset(height);
+    }
+
+    // At the end of rendering, we need to pop those matrices we pushed.
+    @Inject(method = "render", at = @At(value = "RETURN"))
+    public void popRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        context.getMatrices().pop();
+    }
+}

--- a/src/main/java/me/chrr/scribble/mixin/LecternScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/LecternScreenMixin.java
@@ -1,0 +1,30 @@
+package me.chrr.scribble.mixin;
+
+import me.chrr.scribble.Scribble;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.LecternScreen;
+import net.minecraft.client.gui.widget.Widget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(LecternScreen.class)
+public abstract class LecternScreenMixin extends Screen {
+    // Dummy constructor to match super class.
+    private LecternScreenMixin() {
+        super(null);
+    }
+
+    // If we need to center the GUI, we shift the Y of the close buttons down.
+    @Redirect(method = "addCloseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/LecternScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"))
+    public <T extends Element & Drawable & Selectable> T shiftCloseButtonY(LecternScreen instance, T element) {
+        if (element instanceof Widget widget) {
+            widget.setY(widget.getY() + Scribble.getBookScreenYOffset(height));
+        }
+
+        return addDrawableChild(element);
+    }
+}

--- a/src/main/resources/assets/scribble/lang/en_us.json
+++ b/src/main/resources/assets/scribble/lang/en_us.json
@@ -2,6 +2,7 @@
     "config.scribble.title": "Scribble Config",
     "config.scribble.option.copy_formatting_codes": "Copy formatting codes",
     "config.scribble.description.copy_formatting_codes": "This option can be temporarily disabled by\npressing SHIFT while copying or pasting text.",
+    "config.scribble.option.center_book_gui": "Vertically center book GUI's",
     "text.scribble.action.delete_page": "Delete page",
     "text.scribble.action.insert_new_page": "Insert new page",
     "text.scribble.action.save_book_to_file": "Save book to file...",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,5 +34,8 @@
         "minecraft": "${minecraftDependency}",
         "fabricloader": ">=0.14",
         "fabric-resource-loader-v0": "*"
+    },
+    "breaks": {
+        "fixbookgui": "*"
     }
 }

--- a/src/main/resources/scribble.mixins.json
+++ b/src/main/resources/scribble.mixins.json
@@ -5,7 +5,9 @@
     "compatibilityLevel": "JAVA_17",
     "client": [
         "BookEditScreenMixin",
-        "KeyboardMixin"
+        "BookScreenMixin",
+        "KeyboardMixin",
+        "LecternScreenMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
Fixes #13 

- [x] Center other book screens (book reading, lecterns)
- [ ] ~Shifting the text using matrices feels unnecessary when we're controlling the position of the text.. (although it might improve mod compatibility?)~ this is more work than it's worth
- [x] Add translations for the config options
- [x] Mark FixBookGUI as incompatible in fabric.mod.json

![afbeelding](https://github.com/user-attachments/assets/e6f81ce6-40f6-485f-875e-6935c664d7dd)

(needs more testing, it feels very hacky at the moment, but it might be fine?)