### PR TITLE
Add undo/redo history size to config screen

### DIFF
--- a/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
+++ b/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
@@ -57,6 +57,16 @@ public class ClothConfigScreenFactory {
                 .setSaveConsumer((value) -> config.showSaveLoadButtons = value)
                 .build());
 
+        category.addEntry(entryBuilder.startIntSlider(
+                        Text.translatable("config.scribble.option.edit_history_size"),
+                        config.editHistorySize,
+                        8,
+                        128
+                )
+                .setDefaultValue(Config.DEFAULT.editHistorySize)
+                .setSaveConsumer((value) -> config.editHistorySize = value)
+                .build());
+
         return builder.build();
     }
 }

--- a/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
+++ b/src/main/java/me/chrr/scribble/compat/ClothConfigScreenFactory.java
@@ -36,7 +36,7 @@ public class ClothConfigScreenFactory {
                         Text.translatable("config.scribble.option.copy_formatting_codes"),
                         config.copyFormattingCodes
                 )
-                .setDefaultValue(true)
+                .setDefaultValue(Config.DEFAULT.copyFormattingCodes)
                 .setTooltip(Text.translatable("config.scribble.description.copy_formatting_codes"))
                 .setSaveConsumer((value) -> config.copyFormattingCodes = value)
                 .build());
@@ -45,7 +45,7 @@ public class ClothConfigScreenFactory {
                         Text.translatable("config.scribble.option.center_book_gui"),
                         config.centerBookGui
                 )
-                .setDefaultValue(true)
+                .setDefaultValue(Config.DEFAULT.centerBookGui)
                 .setSaveConsumer((value) -> config.centerBookGui = value)
                 .build());
 
@@ -53,7 +53,7 @@ public class ClothConfigScreenFactory {
                         Text.translatable("config.scribble.option.show_save_load_buttons"),
                         config.showSaveLoadButtons
                 )
-                .setDefaultValue(true)
+                .setDefaultValue(Config.DEFAULT.showSaveLoadButtons)
                 .setSaveConsumer((value) -> config.showSaveLoadButtons = value)
                 .build());
 

--- a/src/main/java/me/chrr/scribble/config/Config.java
+++ b/src/main/java/me/chrr/scribble/config/Config.java
@@ -3,6 +3,8 @@ package me.chrr.scribble.config;
 import com.google.gson.annotations.SerializedName;
 
 public class Config {
+
+    public static Config DEFAULT = new Config();
     public static int VERSION = 2;
 
     @SerializedName("version")
@@ -16,6 +18,9 @@ public class Config {
 
     @SerializedName("show_save_load_buttons")
     public boolean showSaveLoadButtons = true;
+
+    @SerializedName("edit_history_size")
+    public int editHistorySize = 32;
 
     public void upgrade() {
         this.version = VERSION;

--- a/src/main/java/me/chrr/scribble/config/Config.java
+++ b/src/main/java/me/chrr/scribble/config/Config.java
@@ -5,10 +5,9 @@ import com.google.gson.annotations.SerializedName;
 public class Config {
 
     public static Config DEFAULT = new Config();
-    public static int VERSION = 2;
 
     @SerializedName("version")
-    public int version = VERSION;
+    public int version = 2;
 
     @SerializedName("copy_formatting_codes")
     public boolean copyFormattingCodes = true;
@@ -23,6 +22,6 @@ public class Config {
     public int editHistorySize = 32;
 
     public void upgrade() {
-        this.version = VERSION;
+        this.version = DEFAULT.version;
     }
 }

--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -53,8 +53,6 @@ import net.minecraft.component.type.WritableBookContentComponent;
 
 @Mixin(BookEditScreen.class)
 public abstract class BookEditScreenMixin extends Screen implements PagesListener, Restorable<BookEditScreenMemento> {
-    @Unique
-    private static final int BOOK_EDIT_HISTORY_SIZE = 30;
 
     @Unique
     private static final int MAX_PAGES_NUMBER = 100;
@@ -127,7 +125,9 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     private final List<RichText> richPages = new ArrayList<>();
 
     @Unique
-    private final CommandManager commandManager = new CommandManager(BOOK_EDIT_HISTORY_SIZE);
+    private final CommandManager commandManager = new CommandManager(
+            Scribble.CONFIG_MANAGER.getConfig().editHistorySize
+    );
 
     @Unique
     @Nullable

--- a/src/main/resources/assets/scribble/lang/en_us.json
+++ b/src/main/resources/assets/scribble/lang/en_us.json
@@ -4,6 +4,7 @@
     "config.scribble.description.copy_formatting_codes": "This option can be temporarily disabled by\npressing SHIFT while copying or pasting text.",
     "config.scribble.option.center_book_gui": "Vertically center book GUI's",
     "config.scribble.option.show_save_load_buttons": "Show save/load buttons",
+    "config.scribble.option.edit_history_size": "Undo/redo history size",
     "text.scribble.action.delete_page": "Delete page",
     "text.scribble.action.insert_new_page": "Insert new page",
     "text.scribble.action.save_book_to_file": "Save book to file...",

--- a/src/main/resources/assets/scribble/lang/ru_ru.json
+++ b/src/main/resources/assets/scribble/lang/ru_ru.json
@@ -4,6 +4,7 @@
     "config.scribble.description.copy_formatting_codes": "Эта опция может быть временно отключена,\nнажав SHIFT при копировании или вставке текста.",
     "config.scribble.option.center_book_gui": "Выравнивать интерфейс книги по вертикали",
     "config.scribble.option.show_save_load_buttons": "Показывать кнопки сохранения/загрузки",
+    "config.scribble.option.edit_history_size": "Размер истории редактирования",
     "text.scribble.action.delete_page": "Удалить страницу",
     "text.scribble.action.insert_new_page": "Вставить новую страницу",
     "text.scribble.action.save_book_to_file": "Сохранить книгу в файл...",


### PR DESCRIPTION
Replace hardcoded undo/redo history size with configurable value.

- added value to Config class
- added slider to ClothConfig screen (min:8 max:128)
- changed the default value from 30 to 32
- added `en` and `ru` localization for the new option

![image](https://github.com/user-attachments/assets/37daedbd-96f1-4ff6-8fb4-728e153c03d9)
