### PR TITLE
fix: prevent executing insert command when loading empty books

### DIFF
--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -456,20 +456,15 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
     private void loadFrom(Path path) {
         try {
             BookFile bookFile = BookFile.read(path);
+            Collection<RichText> loadedPages = bookFile.pages().isEmpty()
+                    ? List.of(RichText.empty()) // if loaded book has no pages, then create an empty page
+                    : bookFile.pages();
 
-            this.richPages.clear();
-            this.pages.clear();
+            richPages.clear();
+            pages.clear();
             commandManager.clear();
 
-            // Loading an empty book file would set the total amount of pages to 0.
-            // We work around this by just inserting a new empty page.
-            if (bookFile.pages().isEmpty()) {
-                this.currentPage = 0;
-                this.insertPage();
-                return;
-            }
-
-            for (RichText page : bookFile.pages()) {
+            for (RichText page : loadedPages) {
                 this.richPages.add(page);
                 this.pages.add(page.getAsFormattedString());
             }


### PR DESCRIPTION
Bugfix PR

## Bug description

When a user loads a book file with 0 pages, the "insert new page" command is executed and added to the undo stack. The command can be undone manually that leads to an unexpected state.

### Steps to reproduce:
1. Load a book from a file with 0 pages
2. Press undo (Ctrl + Z)

### Expected behavior:
- Nothing changes, the blank first book page is opened

### Actual behavior:
- The total book's page number changes to 0
- The user is not able to edit the page content

![image](https://github.com/user-attachments/assets/679ec33f-b51d-4d9d-97bf-7638829a6912)


## Zero-pages book file example:

```nbt
"": {
	pages: [ ]
	author: Player435
}
```