### PR TITLE
impr: delegate pages synchronization to a dedicated class

### DIFF
--- a/src/main/java/me/chrr/scribble/book/SynchronizedPageList.java
+++ b/src/main/java/me/chrr/scribble/book/SynchronizedPageList.java
@@ -1,0 +1,113 @@
+package me.chrr.scribble.book;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * A class responsible for synchronizing a list of formatted strings ({@link SynchronizedPageList#pages})
+ * with a list of {@link RichText} objects ({@link SynchronizedPageList#richPages}).
+ * <p>
+ * This class ensures that any modification to one list is reflected in the other,
+ * maintaining consistency between the two.
+ */
+@SuppressWarnings("UnusedReturnValue")
+public class SynchronizedPageList {
+
+    private final List<RichText> richPages;
+    private List<String> pages;
+
+    private static List<RichText> createRichPages(List<String> pages) {
+        return pages.stream().map(RichText::fromFormattedString).toList();
+    }
+
+    public SynchronizedPageList(List<String> pages, List<RichText> richPages) {
+        this.pages = pages;
+        this.richPages = richPages;
+    }
+
+    public SynchronizedPageList() {
+        // use ArrayList to keep collections mutable
+        this(new ArrayList<>(), new ArrayList<>());
+    }
+
+    /**
+     * Populates the {@link SynchronizedPageList#pages}` and {@link SynchronizedPageList#richPages} lists
+     * with the provided strings.
+     * The {@link SynchronizedPageList#pages} reference link is updated.
+     * The {@link SynchronizedPageList#richPages} reference is remains the same. The list is cleared and recreated from the strings.
+     *
+     * @param pages The list of formatted strings to populate the `pages` and `richPages` lists.
+     */
+    public void populate(List<String> pages) {
+        this.pages = pages;
+
+        this.richPages.clear();
+        this.richPages.addAll(createRichPages(pages));
+    }
+
+    public RichText set(int index, RichText richText) {
+        RichText result = richPages.set(index, richText);
+        pages.set(index, richText.getAsFormattedString());
+        return result;
+    }
+
+    public boolean add(RichText richText) {
+        richPages.add(richText);
+        pages.add(richText.getAsFormattedString());
+        return true;
+    }
+
+    public void add(int index, RichText richText) {
+        richPages.add(index, richText);
+        pages.add(index, richText.getAsFormattedString());
+    }
+
+    public boolean addAll(@NotNull Collection<? extends RichText> collection) {
+        boolean result = richPages.addAll(collection);
+        collection.forEach((richText) -> pages.add(richText.getAsFormattedString()));
+        return result;
+    }
+
+    public RichText remove(int index) {
+        RichText removed = richPages.remove(index);
+        pages.remove(index);
+        return removed;
+    }
+
+    public void clear() {
+        richPages.clear();
+        pages.clear();
+    }
+
+    public RichText get(int index) {
+        return richPages.get(index);
+    }
+
+    public List<RichText> getRichPages() {
+        // return immutable copy of richPages
+        return List.copyOf(richPages);
+    }
+
+    public List<String> getPages() {
+        // return immutable copy of pages
+        return List.copyOf(pages);
+    }
+
+    public int size() {
+        return richPages.size();
+    }
+
+    public boolean isEmpty() {
+        return richPages.isEmpty();
+    }
+
+    public boolean arePagesEmpty() {
+        for (RichText page : richPages) {
+            if (!page.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/me/chrr/scribble/book/SynchronizedPageList.java
+++ b/src/main/java/me/chrr/scribble/book/SynchronizedPageList.java
@@ -11,7 +11,6 @@ import java.util.*;
  * This class ensures that any modification to one list is reflected in the other,
  * maintaining consistency between the two.
  */
-@SuppressWarnings("UnusedReturnValue")
 public class SynchronizedPageList {
 
     private final List<RichText> richPages;
@@ -63,12 +62,14 @@ public class SynchronizedPageList {
         pages.add(index, richText.getAsFormattedString());
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public boolean addAll(@NotNull Collection<? extends RichText> collection) {
         boolean result = richPages.addAll(collection);
         collection.forEach((richText) -> pages.add(richText.getAsFormattedString()));
         return result;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public RichText remove(int index) {
         RichText removed = richPages.remove(index);
         pages.remove(index);

--- a/src/main/java/me/chrr/scribble/history/command/DeletePageCommand.java
+++ b/src/main/java/me/chrr/scribble/history/command/DeletePageCommand.java
@@ -1,14 +1,13 @@
 package me.chrr.scribble.history.command;
 
 import me.chrr.scribble.Scribble;
+import me.chrr.scribble.book.SynchronizedPageList;
 import me.chrr.scribble.book.RichText;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-
 public class DeletePageCommand implements Command {
 
-    private final List<RichText> pages;
+    private final SynchronizedPageList pages;
     private final int index;
 
     private final PagesListener pagesListener;
@@ -16,7 +15,7 @@ public class DeletePageCommand implements Command {
     @Nullable
     private RichText deletedPage;
 
-    public DeletePageCommand(List<RichText> pages, int index, PagesListener pagesListener) {
+    public DeletePageCommand(SynchronizedPageList pages, int index, PagesListener pagesListener) {
         if (index < 0 || index >= pages.size()) {
             throw new IllegalArgumentException("Delete page index is out of pages range");
         }

--- a/src/main/java/me/chrr/scribble/history/command/InsertPageCommand.java
+++ b/src/main/java/me/chrr/scribble/history/command/InsertPageCommand.java
@@ -1,17 +1,16 @@
 package me.chrr.scribble.history.command;
 
+import me.chrr.scribble.book.SynchronizedPageList;
 import me.chrr.scribble.book.RichText;
-
-import java.util.List;
 
 public class InsertPageCommand implements Command {
 
-    private final List<RichText> pages;
+    private final SynchronizedPageList pages;
     private final int index;
 
     private final PagesListener pagesListener;
 
-    public InsertPageCommand(List<RichText> pages, int index, PagesListener pagesListener) {
+    public InsertPageCommand(SynchronizedPageList pages, int index, PagesListener pagesListener) {
         if (index < 0 || index > pages.size()) {
             throw new IllegalArgumentException("Insert page index is out of pages range");
         }

--- a/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/BookEditScreenMixin.java
@@ -627,8 +627,6 @@ public abstract class BookEditScreenMixin extends Screen implements PagesListene
 
     @Redirect(method = "appendNewPage", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z"))
     private boolean appendNewPage(List<String> page, Object empty) {
-        // FIXME: It feels slightly confusing that we pass in richPages here, but at the same time
-        //        use PagesListener to add plain-text pages. It makes it hard to follow.
         Command command = new InsertPageCommand(synchronizedPages, synchronizedPages.size(), this);
         commandManager.execute(command);
         return true;

--- a/src/test/java/me/chrr/scribble/DeletePageCommandTest.java
+++ b/src/test/java/me/chrr/scribble/DeletePageCommandTest.java
@@ -1,36 +1,27 @@
 package me.chrr.scribble;
 
+import me.chrr.scribble.book.SynchronizedPageList;
 import me.chrr.scribble.book.RichText;
 import me.chrr.scribble.history.command.DeletePageCommand;
 import me.chrr.scribble.history.command.PagesListener;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import static me.chrr.scribble.mixture.CommonMixture.mockSynchronizedPageList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class DeletePageCommandTest {
 
-    private static List<RichText> mockPageList(int size) {
-        ArrayList<RichText> list = new ArrayList<>(size);
-
-        for (int i = 0; i < size; i++) {
-            RichText item = RichText.fromFormattedString("page content:" + i);
-            list.add(item);
-        }
-
-        return list;
-    }
-
     @Test
     public void testIfPagesListenerOnPageRemovedIsCalledAfterExecution() {
         PagesListener pagesListener = mock();
         int deleteIndex = 2;
         int size = deleteIndex + 2;
-        DeletePageCommand deletePageCommand = new DeletePageCommand(mockPageList(size), deleteIndex, pagesListener);
+        DeletePageCommand deletePageCommand =
+                new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, pagesListener);
 
         // Action
         deletePageCommand.execute();
@@ -44,7 +35,8 @@ public class DeletePageCommandTest {
         PagesListener pagesListener = mock();
         int size = 1;
         int deleteIndex = 0;
-        DeletePageCommand deletePageCommand = new DeletePageCommand(mockPageList(size), deleteIndex, pagesListener);
+        DeletePageCommand deletePageCommand =
+                new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, pagesListener);
 
         // Action
         deletePageCommand.execute();
@@ -59,7 +51,7 @@ public class DeletePageCommandTest {
         PagesListener pagesListener = mock();
         int deleteIndex = 2;
         int size = deleteIndex + 2;
-        List<RichText> pages = mockPageList(size);
+        SynchronizedPageList pages = mockSynchronizedPageList(size);
         DeletePageCommand deletePageCommand = new DeletePageCommand(pages, deleteIndex, pagesListener);
         deletePageCommand.execute();
 
@@ -76,7 +68,7 @@ public class DeletePageCommandTest {
         PagesListener pagesListener = mock();
         int size = 1;
         int deleteIndex = 0;
-        List<RichText> pages = mockPageList(size);
+        SynchronizedPageList pages = mockSynchronizedPageList(size);
         DeletePageCommand deletePageCommand = new DeletePageCommand(pages, deleteIndex, pagesListener);
         deletePageCommand.execute();
 
@@ -91,40 +83,41 @@ public class DeletePageCommandTest {
     public void testIfRemovesRichPageFromTheListOnExecute() {
         int deleteIndex = 1;
         int size = deleteIndex + 1;
-        List<RichText> richPages = mockPageList(size);
-        RichText pageToDelete = richPages.get(deleteIndex);
+        SynchronizedPageList synchronizedPageList = mockSynchronizedPageList(size);
+        RichText pageToDelete = synchronizedPageList.get(deleteIndex);
 
-        DeletePageCommand deletePageCommand = new DeletePageCommand(richPages, deleteIndex, mock());
+        DeletePageCommand deletePageCommand = new DeletePageCommand(synchronizedPageList, deleteIndex, mock());
 
         // Action
         deletePageCommand.execute();
 
         // Assert
-        assertFalse(richPages.contains(pageToDelete));
+        assertFalse(synchronizedPageList.getRichPages().contains(pageToDelete));
     }
 
     @Test
     public void testIfRollbacksRichPagesToOriginState() {
         int deleteIndex = 3;
         int size = deleteIndex + 1;
-        List<RichText> richPages = mockPageList(size);
-        List<RichText> originRichPages = List.copyOf(richPages);
+        SynchronizedPageList synchronizedPageList = mockSynchronizedPageList(size);
+        List<RichText> originRichPages = synchronizedPageList.getRichPages();
 
-        DeletePageCommand deletePageCommand = new DeletePageCommand(richPages, deleteIndex, mock());
+        DeletePageCommand deletePageCommand = new DeletePageCommand(synchronizedPageList, deleteIndex, mock());
 
         // Action
         deletePageCommand.execute();
         deletePageCommand.rollback();
 
         // Assert
-        assertEquals(originRichPages, richPages);
+        assertEquals(originRichPages, synchronizedPageList.getRichPages());
     }
 
     @Test
     public void testIfRollbacksReturnsFalseIfCommandWasNotExecuted() {
         int deleteIndex = 3;
         int size = deleteIndex + 1;
-        DeletePageCommand deletePageCommand = new DeletePageCommand(mockPageList(size), deleteIndex, mock());
+        DeletePageCommand deletePageCommand =
+                new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, mock());
 
         // Action / Assert
         assertFalse(deletePageCommand.rollback());
@@ -138,7 +131,7 @@ public class DeletePageCommandTest {
         // Action / Assert
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new DeletePageCommand(mockPageList(size), deleteIndex, mock())
+                () -> new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, mock())
         );
     }
 
@@ -150,7 +143,7 @@ public class DeletePageCommandTest {
         // Action / Assert
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new DeletePageCommand(mockPageList(size), deleteIndex, mock())
+                () -> new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, mock())
         );
     }
 
@@ -162,7 +155,7 @@ public class DeletePageCommandTest {
         // Action / Assert
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new DeletePageCommand(mockPageList(size), deleteIndex, mock())
+                () -> new DeletePageCommand(mockSynchronizedPageList(size), deleteIndex, mock())
         );
     }
 }

--- a/src/test/java/me/chrr/scribble/InsertPageCommandTest.java
+++ b/src/test/java/me/chrr/scribble/InsertPageCommandTest.java
@@ -1,36 +1,23 @@
 package me.chrr.scribble;
 
-import me.chrr.scribble.book.RichText;
 import me.chrr.scribble.history.command.InsertPageCommand;
 import me.chrr.scribble.history.command.PagesListener;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import static me.chrr.scribble.mixture.CommonMixture.mockSynchronizedPageList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class InsertPageCommandTest {
 
-    private static List<RichText> mockPageList(int size) {
-        ArrayList<RichText> list = new ArrayList<>(size);
-
-        for (int i = 0; i < size; i++) {
-            RichText item = RichText.fromFormattedString("page content:" + i);
-            list.add(item);
-        }
-
-        return list;
-    }
-
     @Test
     public void testIfPagesListenerOnPageAddedIsCalledAfterExecution() {
         PagesListener pagesListener = mock();
         int insertIndex = 2;
         int size = insertIndex + 2;
-        InsertPageCommand insertPageCommand = new InsertPageCommand(mockPageList(size), insertIndex, pagesListener);
+        InsertPageCommand insertPageCommand =
+                new InsertPageCommand(mockSynchronizedPageList(size), insertIndex, pagesListener);
 
         // Action
         insertPageCommand.execute();
@@ -44,7 +31,8 @@ public class InsertPageCommandTest {
         PagesListener pagesListener = mock();
         int insertIndex = 2;
         int size = insertIndex + 2;
-        InsertPageCommand insertPageCommand = new InsertPageCommand(mockPageList(size), insertIndex, pagesListener);
+        InsertPageCommand insertPageCommand =
+                new InsertPageCommand(mockSynchronizedPageList(size), insertIndex, pagesListener);
         insertPageCommand.execute();
 
         // Action
@@ -62,7 +50,7 @@ public class InsertPageCommandTest {
         // Action / Assert
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new InsertPageCommand(mockPageList(size), insertIndex, mock())
+                () -> new InsertPageCommand(mockSynchronizedPageList(size), insertIndex, mock())
         );
     }
 
@@ -74,7 +62,7 @@ public class InsertPageCommandTest {
         // Action / Assert
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new InsertPageCommand(mockPageList(size), insertIndex, mock())
+                () -> new InsertPageCommand(mockSynchronizedPageList(size), insertIndex, mock())
         );
     }
 

--- a/src/test/java/me/chrr/scribble/SynchronizedPageListTest.java
+++ b/src/test/java/me/chrr/scribble/SynchronizedPageListTest.java
@@ -1,0 +1,181 @@
+package me.chrr.scribble;
+
+import me.chrr.scribble.book.SynchronizedPageList;
+import me.chrr.scribble.book.RichText;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static me.chrr.scribble.mixture.CommonMixture.mockPages;
+import static me.chrr.scribble.mixture.CommonMixture.mockSynchronizedPageList;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("SequencedCollectionMethodCanBeUsed")
+public class SynchronizedPageListTest {
+
+    @Test
+    public void getRichPagesShouldReturnListCopyWhenCalled() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(3);
+
+        // Action
+        List<RichText> firstActual = synchronizedList.getRichPages();
+        List<RichText> secondActual = synchronizedList.getRichPages();
+
+        // Assert
+        assertEquals(firstActual, secondActual);
+        assertNotSame(firstActual, secondActual);
+    }
+
+
+    @Test
+    public void populatePagesShouldUpdateRich() {
+        List<String> initialPages = mockPages(1, "init");
+        List<String> newPages = mockPages(1, "new");
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+        synchronizedList.populate(initialPages);
+
+        // Action
+        synchronizedList.populate(newPages);
+
+        // Assert
+        assertNotEquals(RichText.fromFormattedString(initialPages.get(0)), synchronizedList.getRichPages().get(0));
+        assertEquals(newPages.size(), synchronizedList.size());
+        assertEquals(RichText.fromFormattedString(newPages.get(0)), synchronizedList.getRichPages().get(0));
+    }
+
+    @Test
+    public void setShouldUpdateBothLists() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
+        RichText newRichText = RichText.fromFormattedString("Updated Page");
+
+        // Action
+        synchronizedList.set(0, newRichText);
+
+        // Assert
+        assertEquals(newRichText, synchronizedList.getRichPages().get(0));
+        assertEquals(newRichText.getAsFormattedString(), synchronizedList.getPages().get(0));
+    }
+
+    @Test
+    public void addRichTextShouldAddToBothLists() {
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+        RichText newRichText = RichText.fromFormattedString("New Page");
+
+        // Action
+        synchronizedList.add(newRichText);
+
+        // Assert
+        assertEquals(1, synchronizedList.size());
+        assertEquals(newRichText, synchronizedList.getRichPages().get(0));
+        assertEquals(newRichText.getAsFormattedString(), synchronizedList.getPages().get(0));
+    }
+
+    @Test
+    public void addRichTextAtIndexShouldAddToBothLists() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
+        RichText newRichText = RichText.fromFormattedString("New Page");
+
+        // Action
+        synchronizedList.add(0, newRichText);
+
+        // Assert
+        assertEquals(2, synchronizedList.size());
+        assertEquals(newRichText, synchronizedList.getRichPages().get(0));
+        assertEquals(newRichText.getAsFormattedString(), synchronizedList.getPages().get(0));
+    }
+
+    @Test
+    public void addAllCollectionShouldAddToBothLists() {
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+        List<RichText> newRichTexts = List.of(
+                RichText.fromFormattedString("Page 1"),
+                RichText.fromFormattedString("Page 2")
+        );
+
+        // Action
+        synchronizedList.addAll(newRichTexts);
+
+        // Assert
+        assertEquals(2, synchronizedList.size());
+        assertEquals(newRichTexts.get(0), synchronizedList.getRichPages().get(0));
+        assertEquals(newRichTexts.get(1), synchronizedList.getRichPages().get(1));
+        assertEquals(newRichTexts.get(0).getAsFormattedString(), synchronizedList.getPages().get(0));
+        assertEquals(newRichTexts.get(1).getAsFormattedString(), synchronizedList.getPages().get(1));
+    }
+
+    @Test
+    public void removeShouldRemoveFromBothLists() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
+
+        // Action
+        synchronizedList.remove(0);
+
+        // Assert
+        assertEquals(0, synchronizedList.size());
+        assertTrue(synchronizedList.getRichPages().isEmpty());
+        assertTrue(synchronizedList.getPages().isEmpty());
+    }
+
+    @Test
+    public void clearShouldClearBothLists() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
+
+        // Action
+        synchronizedList.clear();
+
+        // Assert
+        assertEquals(0, synchronizedList.size());
+        assertTrue(synchronizedList.getRichPages().isEmpty());
+        assertTrue(synchronizedList.getPages().isEmpty());
+    }
+
+    @Test
+    public void sizeShouldReturnSizeOfRichPages() {
+        int initialSize = 2;
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(initialSize);
+
+        int actual = synchronizedList.size();
+
+        assertEquals(initialSize, actual);
+    }
+
+    @Test
+    public void isEmptyShouldReturnTrueWhenRichPagesIsEmpty() {
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+
+        boolean actual = synchronizedList.isEmpty();
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isEmptyShouldReturnFalseWhenRichPagesIsNotEmpty() {
+        SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
+
+        boolean actual = synchronizedList.isEmpty();
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void arePagesEmptyShouldReturnTrueWhenAllPagesAreEmpty() {
+        List<String> pages = List.of("", "");
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+        synchronizedList.populate(pages);
+
+        boolean actual = synchronizedList.arePagesEmpty();
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void arePagesEmptyShouldReturnFalseWhenAtLeastOnePageIsNotEmpty() {
+        List<String> pages = List.of("", "not empty");
+        SynchronizedPageList synchronizedList = new SynchronizedPageList();
+        synchronizedList.populate(pages);
+
+        boolean actual = synchronizedList.arePagesEmpty();
+
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/me/chrr/scribble/SynchronizedPageListTest.java
+++ b/src/test/java/me/chrr/scribble/SynchronizedPageListTest.java
@@ -10,7 +10,6 @@ import static me.chrr.scribble.mixture.CommonMixture.mockPages;
 import static me.chrr.scribble.mixture.CommonMixture.mockSynchronizedPageList;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("SequencedCollectionMethodCanBeUsed")
 public class SynchronizedPageListTest {
 
     @Test
@@ -28,6 +27,7 @@ public class SynchronizedPageListTest {
 
 
     @Test
+    @SuppressWarnings("SequencedCollectionMethodCanBeUsed")
     public void populatePagesShouldUpdateRich() {
         List<String> initialPages = mockPages(1, "init");
         List<String> newPages = mockPages(1, "new");
@@ -44,6 +44,7 @@ public class SynchronizedPageListTest {
     }
 
     @Test
+    @SuppressWarnings("SequencedCollectionMethodCanBeUsed")
     public void setShouldUpdateBothLists() {
         SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
         RichText newRichText = RichText.fromFormattedString("Updated Page");
@@ -57,6 +58,7 @@ public class SynchronizedPageListTest {
     }
 
     @Test
+    @SuppressWarnings("SequencedCollectionMethodCanBeUsed")
     public void addRichTextShouldAddToBothLists() {
         SynchronizedPageList synchronizedList = new SynchronizedPageList();
         RichText newRichText = RichText.fromFormattedString("New Page");
@@ -71,6 +73,7 @@ public class SynchronizedPageListTest {
     }
 
     @Test
+    @SuppressWarnings("SequencedCollectionMethodCanBeUsed")
     public void addRichTextAtIndexShouldAddToBothLists() {
         SynchronizedPageList synchronizedList = mockSynchronizedPageList(1);
         RichText newRichText = RichText.fromFormattedString("New Page");

--- a/src/test/java/me/chrr/scribble/mixture/CommonMixture.java
+++ b/src/test/java/me/chrr/scribble/mixture/CommonMixture.java
@@ -1,0 +1,30 @@
+package me.chrr.scribble.mixture;
+
+import me.chrr.scribble.book.SynchronizedPageList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CommonMixture {
+
+    public static List<String> mockPages(int size, String prefix) {
+        ArrayList<String> list = new ArrayList<>(size);
+
+        for (int i = 0; i < size; i++) {
+            list.add(prefix + "-page content:" + i);
+        }
+
+        return list;
+    }
+
+    public static List<String> mockPages(int size) {
+        return mockPages(size, "none");
+    }
+
+    public static SynchronizedPageList mockSynchronizedPageList(int size) {
+        SynchronizedPageList synchronizedPageList = new SynchronizedPageList();
+        synchronizedPageList.populate(mockPages(size));
+        return synchronizedPageList;
+    }
+
+}


### PR DESCRIPTION
The PR is inspired by this [comments](https://github.com/chrrs/scribble/commit/81965855646f25088d421cc7573f025b5ee05da7#r151764451).

Introducing a class dedicated to keeping the `richPages` collection in sync with vanilla Minecraft pages - `SynchronizedPageList`.

The idea is to use `SynchronizedPageList` instance to perform all operations on `richPages`. The `SynchronizedPageList` will take care of keeping it in sync with `pages`.