### PR TITLE
Modify KeyboardMixin for compatibility

### DIFF
--- a/src/main/java/me/chrr/scribble/mixin/KeyboardMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/KeyboardMixin.java
@@ -18,7 +18,7 @@ public class KeyboardMixin {
     private MinecraftClient client;
 
     // Disable the narrator hotkey when editing a book.
-    @WrapOperation(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;"))
+    @WrapOperation(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;", ordinal = 0))
     private Object getValue(SimpleOption<?> instance, Operation<?> original) {
         if (client.currentScreen instanceof BookEditScreen) return false;
         else return original.call(instance);

--- a/src/main/java/me/chrr/scribble/mixin/KeyboardMixin.java
+++ b/src/main/java/me/chrr/scribble/mixin/KeyboardMixin.java
@@ -1,15 +1,15 @@
 package me.chrr.scribble.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.Keyboard;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.BookEditScreen;
-import org.lwjgl.glfw.GLFW;
+import net.minecraft.client.option.SimpleOption;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(Keyboard.class)
 public class KeyboardMixin {
@@ -18,16 +18,9 @@ public class KeyboardMixin {
     private MinecraftClient client;
 
     // Disable the narrator hotkey when editing a book.
-    // We mix into the constant, because there's not really many other good places
-    // that we can mixin into to change the condition.
-    @ModifyConstant(method = "onKey", constant = @Constant(intValue = GLFW.GLFW_KEY_B))
-    public int getNarratorKey(int constant) {
-        if (client.currentScreen instanceof BookEditScreen && !Screen.hasShiftDown()) {
-            // We'll change the key needed to activate the narrator to
-            // a known non-existent key if we're currently editing a book.
-            return GLFW.GLFW_KEY_LAST + 1;
-        } else {
-            return GLFW.GLFW_KEY_B;
-        }
+    @WrapOperation(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;"))
+    private Object getValue(SimpleOption<?> instance, Operation<?> original) {
+        if (client.currentScreen instanceof BookEditScreen) return false;
+        else return original.call(instance);
     }
 }


### PR DESCRIPTION
KeyboardMixin currently is not very compatible with mods that allow rebinding the narrator key, therefore use @WrapOperation instead on another function for the same result but better compatibility.